### PR TITLE
Add interactive resume scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,15 @@
 
 [fingerskier blog](https://fingerskier.github.io)
 
+## Playable Resume
+
+The `/app` directory holds a small React application that renders a side‑scrolling resume.
+Install dependencies and start the dev server with:
+
+```bash
+cd app
+npm install
+npm run dev
+```
+
+Use the left and right arrow keys to navigate between sections. Update `app/src/resume.json` with your own information to populate the game.

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -1,42 +1,4 @@
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
-}
-
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
+  margin: 0;
+  padding: 0;
 }

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,35 +1,8 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import ResumeGame from './ResumeGame'
 import './App.css'
 
 function App() {
-  const [count, setCount] = useState(0)
-
-  return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+  return <ResumeGame />
 }
 
 export default App

--- a/app/src/ResumeGame.css
+++ b/app/src/ResumeGame.css
@@ -1,0 +1,29 @@
+.resume-game {
+  overflow: hidden;
+  width: 100vw;
+  height: 100vh;
+  position: relative;
+}
+
+.sections-container {
+  display: flex;
+  transition: transform 0.3s ease-in-out;
+  height: 100%;
+}
+
+.section {
+  flex: 0 0 100vw;
+  padding: 2rem;
+  box-sizing: border-box;
+}
+
+.controls {
+  position: absolute;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0,0,0,0.5);
+  color: white;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+}

--- a/app/src/ResumeGame.tsx
+++ b/app/src/ResumeGame.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react'
+import resumeData from './resume.json'
+import './ResumeGame.css'
+
+type Section = {
+  title: string
+  content: string
+}
+
+function ResumeGame() {
+  const sections = (resumeData as { sections: Section[] }).sections
+  const [index, setIndex] = useState(0)
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowRight') {
+        setIndex((i) => Math.min(i + 1, sections.length - 1))
+      } else if (e.key === 'ArrowLeft') {
+        setIndex((i) => Math.max(i - 1, 0))
+      }
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [sections.length])
+
+  return (
+    <div className="resume-game">
+      <div
+        className="sections-container"
+        style={{ transform: `translateX(-${index * 100}vw)` }}
+      >
+        {sections.map((s, idx) => (
+          <section key={idx} className="section">
+            <h2>{s.title}</h2>
+            <p>{s.content}</p>
+          </section>
+        ))}
+      </div>
+      <div className="controls">Use ← and → to navigate</div>
+    </div>
+  )
+}
+
+export default ResumeGame

--- a/app/src/resume.json
+++ b/app/src/resume.json
@@ -1,0 +1,1 @@
+{"sections": [{"title": "About", "content": "Your details here"}]}


### PR DESCRIPTION
## Summary
- overhaul React app to show an interactive CV
- provide placeholder JSON data
- document how to run the playable resume

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68559d46bc9483279bc781c55111ecf5