### PR TITLE
Add CV viewer with impress.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ npm run dev
 ```
 
 Use the left and right arrow keys to navigate between sections. Update `app/src/resume.json` with your own information to populate the game.
+
+## CV Play
+
+A simple Impress.js viewer lives in the `/play` directory. It loads `cv.json` and turns it into a series of slides with a small scoring mechanic. Open `play/index.html` in a browser to try it out. Edit `cv.txt` and run `node scripts/convert-cv.js` to regenerate `cv.json`.

--- a/cv.json
+++ b/cv.json
@@ -1,0 +1,11 @@
+{
+  "name": "Sample Candidate",
+  "title": "Software Developer",
+  "experience": [
+    "Example Corp, Developer (2020-2022)",
+    "Another Inc, Engineer (2018-2020)"
+  ],
+  "education": [
+    "B.Sc. Computer Science, Example University (2014-2018)"
+  ]
+}

--- a/cv.txt
+++ b/cv.txt
@@ -1,0 +1,9 @@
+Name: Sample Candidate
+Title: Software Developer
+
+Experience:
+- Example Corp, Developer (2020-2022)
+- Another Inc, Engineer (2018-2020)
+
+Education:
+- B.Sc. Computer Science, Example University (2014-2018)

--- a/play/index.html
+++ b/play/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CV Play</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div id="impress">
+    <!-- slides will be injected here -->
+  </div>
+  <div id="score">Score: <span id="score-value">0</span></div>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/impress.js/0.5.3/impress.min.js"></script>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/play/script.js
+++ b/play/script.js
@@ -1,0 +1,38 @@
+fetch('../cv.json')
+  .then(r => r.json())
+  .then(data => {
+    const impressEl = document.getElementById('impress');
+    let index = 0;
+
+    const addStep = (content, x, y) => {
+      const div = document.createElement('div');
+      div.className = 'step';
+      div.innerHTML = content;
+      div.setAttribute('data-x', x);
+      div.setAttribute('data-y', y);
+      impressEl.appendChild(div);
+    };
+
+    addStep(`<h1>${data.name}</h1><p>${data.title}</p>`, 0, 0);
+
+    if (Array.isArray(data.experience)) {
+      data.experience.forEach((exp, i) => {
+        addStep(`<h2>Experience</h2><p>${exp}</p>`, (i+1)*1000, 0);
+      });
+      index += data.experience.length;
+    }
+
+    if (Array.isArray(data.education)) {
+      data.education.forEach((edu, i) => {
+        addStep(`<h2>Education</h2><p>${edu}</p>`, (i+1)*1000, 1000);
+      });
+    }
+
+    impress().init();
+
+    let score = 0;
+    document.addEventListener('impress:stepenter', () => {
+      score += 10;
+      document.getElementById('score-value').textContent = score;
+    });
+  });

--- a/play/style.css
+++ b/play/style.css
@@ -1,0 +1,14 @@
+body {
+  background: #111;
+  color: #fff;
+  font-family: Arial, sans-serif;
+}
+#score {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+}
+.step {
+  font-size: 2em;
+  text-align: center;
+}

--- a/scripts/convert-cv.js
+++ b/scripts/convert-cv.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+
+const inputPath = path.join(__dirname, '..', 'cv.txt');
+const outputPath = path.join(__dirname, '..', 'cv.json');
+
+const text = fs.readFileSync(inputPath, 'utf8');
+const lines = text.split(/\r?\n/);
+const result = {};
+let currentKey = null;
+
+for (let line of lines) {
+  const trimmed = line.trim();
+  if (trimmed === '') continue;
+  if (trimmed.includes(':') && !trimmed.startsWith('-')) {
+    const [key, ...rest] = trimmed.split(':');
+    currentKey = key.trim().toLowerCase();
+    const value = rest.join(':').trim();
+    if (value) {
+      result[currentKey] = value;
+      currentKey = null;
+    } else {
+      result[currentKey] = [];
+    }
+  } else if (trimmed.startsWith('-') && currentKey) {
+    if (!Array.isArray(result[currentKey])) {
+      result[currentKey] = [];
+    }
+    result[currentKey].push(trimmed.slice(1).trim());
+  }
+}
+
+fs.writeFileSync(outputPath, JSON.stringify(result, null, 2));
+console.log('Generated', outputPath);


### PR DESCRIPTION
## Summary
- add example `cv.txt` and conversion script producing `cv.json`
- new `/play` directory with impress.js based resume viewer
- document how to use the new viewer

## Testing
- `node scripts/convert-cv.js`

------
https://chatgpt.com/codex/tasks/task_e_6856f6f59cb0832785dc3b8a04119c4e