### PR TITLE
Fix play viewer schema mismatch

### DIFF
--- a/cv.json
+++ b/cv.json
@@ -12,10 +12,22 @@
         "class": "Apprentice Frontend Cartographer",
         "level": "Level 1 · 1 year of experience",
         "stats": [
-          { "name": "HTML & CSS", "value": "Adept" },
-          { "name": "Accessibility", "value": "Initiate" },
-          { "name": "Pair Programming", "value": "Adept" },
-          { "name": "Problem Solving", "value": "Determined" }
+          {
+            "name": "HTML & CSS",
+            "value": "Adept"
+          },
+          {
+            "name": "Accessibility",
+            "value": "Initiate"
+          },
+          {
+            "name": "Pair Programming",
+            "value": "Adept"
+          },
+          {
+            "name": "Problem Solving",
+            "value": "Determined"
+          }
         ],
         "inventory": [
           "VS Code",
@@ -40,10 +52,22 @@
         "class": "Support Ranger",
         "level": "Level 2 · 2 years of experience",
         "stats": [
-          { "name": "React", "value": "Journeyman" },
-          { "name": "Customer Empathy", "value": "Master" },
-          { "name": "Testing", "value": "Apprentice" },
-          { "name": "Documentation", "value": "Journeyman" }
+          {
+            "name": "React",
+            "value": "Journeyman"
+          },
+          {
+            "name": "Customer Empathy",
+            "value": "Master"
+          },
+          {
+            "name": "Testing",
+            "value": "Apprentice"
+          },
+          {
+            "name": "Documentation",
+            "value": "Journeyman"
+          }
         ],
         "inventory": [
           "Chrome DevTools",
@@ -73,10 +97,22 @@
         "class": "Platform Artificer",
         "level": "Level 4 · 4 years of experience",
         "stats": [
-          { "name": "Design Systems", "value": "Expert" },
-          { "name": "Node.js", "value": "Journeyman" },
-          { "name": "CI/CD", "value": "Expert" },
-          { "name": "Cross-team Facilitation", "value": "Expert" }
+          {
+            "name": "Design Systems",
+            "value": "Expert"
+          },
+          {
+            "name": "Node.js",
+            "value": "Journeyman"
+          },
+          {
+            "name": "CI/CD",
+            "value": "Expert"
+          },
+          {
+            "name": "Cross-team Facilitation",
+            "value": "Expert"
+          }
         ],
         "inventory": [
           "Storybook",
@@ -106,10 +142,22 @@
         "class": "Insight Cartomancer",
         "level": "Level 6 · 6 years of experience",
         "stats": [
-          { "name": "TypeScript", "value": "Adept" },
-          { "name": "Data Visualization", "value": "Expert" },
-          { "name": "SQL", "value": "Journeyman" },
-          { "name": "Stakeholder Alignment", "value": "Master" }
+          {
+            "name": "TypeScript",
+            "value": "Adept"
+          },
+          {
+            "name": "Data Visualization",
+            "value": "Expert"
+          },
+          {
+            "name": "SQL",
+            "value": "Journeyman"
+          },
+          {
+            "name": "Stakeholder Alignment",
+            "value": "Master"
+          }
         ],
         "inventory": [
           "dbt",
@@ -134,10 +182,22 @@
         "class": "Experience Architect",
         "level": "Level 8 · 8 years of experience",
         "stats": [
-          { "name": "Product Strategy", "value": "Master" },
-          { "name": "Leadership", "value": "Master" },
-          { "name": "React", "value": "Expert" },
-          { "name": "System Design", "value": "Expert" }
+          {
+            "name": "Product Strategy",
+            "value": "Master"
+          },
+          {
+            "name": "Leadership",
+            "value": "Master"
+          },
+          {
+            "name": "React",
+            "value": "Expert"
+          },
+          {
+            "name": "System Design",
+            "value": "Expert"
+          }
         ],
         "inventory": [
           "Miro",

--- a/play/script.js
+++ b/play/script.js
@@ -2,7 +2,6 @@ fetch('../cv.json')
   .then(r => r.json())
   .then(data => {
     const impressEl = document.getElementById('impress');
-    let index = 0;
 
     const addStep = (content, x, y) => {
       const div = document.createElement('div');
@@ -13,18 +12,58 @@ fetch('../cv.json')
       impressEl.appendChild(div);
     };
 
-    addStep(`<h1>${data.name}</h1><p>${data.title}</p>`, 0, 0);
+    const character = data.character || {};
+    addStep(
+      `
+        <h1>${character.name || 'Adventurer'}</h1>
+        ${character.tagline ? `<p>${character.tagline}</p>` : ''}
+      `,
+      0,
+      0
+    );
 
-    if (Array.isArray(data.experience)) {
-      data.experience.forEach((exp, i) => {
-        addStep(`<h2>Experience</h2><p>${exp}</p>`, (i+1)*1000, 0);
-      });
-      index += data.experience.length;
-    }
+    if (Array.isArray(data.milestones)) {
+      data.milestones.forEach((milestone, index) => {
+        const baseX = (index + 1) * 1200;
+        const sheet = milestone.sheet || {};
 
-    if (Array.isArray(data.education)) {
-      data.education.forEach((edu, i) => {
-        addStep(`<h2>Education</h2><p>${edu}</p>`, (i+1)*1000, 1000);
+        const statsList = Array.isArray(sheet.stats)
+          ? `<ul class="sheet-list">${sheet.stats
+              .map(stat => `<li><strong>${stat.name}</strong>: ${stat.value}</li>`)
+              .join('')}</ul>`
+          : '';
+
+        const inventoryList = Array.isArray(sheet.inventory)
+          ? `<ul class="sheet-list">${sheet.inventory
+              .map(item => `<li>${item}</li>`)
+              .join('')}</ul>`
+          : '';
+
+        const questsList = Array.isArray(sheet.quests)
+          ? `<ul class="sheet-list quests">${sheet.quests
+              .map(quest => `
+                <li>
+                  <strong>${quest.name}</strong>
+                  ${quest.objective ? `<div>Objective: ${quest.objective}</div>` : ''}
+                  ${quest.outcome ? `<div>Outcome: ${quest.outcome}</div>` : ''}
+                </li>
+              `)
+              .join('')}</ul>`
+          : '';
+
+        addStep(
+          `
+            <h2>${milestone.title || `Stage ${index + 1}`}</h2>
+            ${milestone.summary ? `<p class="summary">${milestone.summary}</p>` : ''}
+            ${milestone.description ? `<p>${milestone.description}</p>` : ''}
+            ${sheet.class || sheet.level ? `<p class="sheet-meta">${[sheet.class, sheet.level].filter(Boolean).join(' · ')}</p>` : ''}
+            ${statsList ? `<h3>Stats</h3>${statsList}` : ''}
+            ${inventoryList ? `<h3>Inventory</h3>${inventoryList}` : ''}
+            ${questsList ? `<h3>Quests</h3>${questsList}` : ''}
+          `,
+          baseX,
+          0
+        );
       });
     }
 

--- a/play/style.css
+++ b/play/style.css
@@ -12,3 +12,36 @@ body {
   font-size: 2em;
   text-align: center;
 }
+
+.step h2 {
+  margin-top: 0.5em;
+}
+
+.step h3 {
+  font-size: 0.8em;
+  margin-top: 0.75em;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.step p {
+  margin: 0.5em auto;
+  max-width: 60vw;
+}
+
+.sheet-list {
+  list-style: none;
+  margin: 0.5em auto;
+  padding: 0;
+  max-width: 50vw;
+  text-align: left;
+}
+
+.sheet-list li {
+  margin-bottom: 0.25em;
+}
+
+.sheet-list.quests li div {
+  font-size: 0.6em;
+  opacity: 0.85;
+}

--- a/scripts/convert-cv.js
+++ b/scripts/convert-cv.js
@@ -1,34 +1,23 @@
 const fs = require('fs');
 const path = require('path');
 
-const inputPath = path.join(__dirname, '..', 'cv.txt');
+const inputPath = path.join(__dirname, '..', 'app', 'src', 'resume.json');
 const outputPath = path.join(__dirname, '..', 'cv.json');
 
-const text = fs.readFileSync(inputPath, 'utf8');
-const lines = text.split(/\r?\n/);
-const result = {};
-let currentKey = null;
+const resumeRaw = fs.readFileSync(inputPath, 'utf8');
+const resumeData = JSON.parse(resumeRaw);
 
-for (let line of lines) {
-  const trimmed = line.trim();
-  if (trimmed === '') continue;
-  if (trimmed.includes(':') && !trimmed.startsWith('-')) {
-    const [key, ...rest] = trimmed.split(':');
-    currentKey = key.trim().toLowerCase();
-    const value = rest.join(':').trim();
-    if (value) {
-      result[currentKey] = value;
-      currentKey = null;
-    } else {
-      result[currentKey] = [];
-    }
-  } else if (trimmed.startsWith('-') && currentKey) {
-    if (!Array.isArray(result[currentKey])) {
-      result[currentKey] = [];
-    }
-    result[currentKey].push(trimmed.slice(1).trim());
-  }
+if (!resumeData || typeof resumeData !== 'object') {
+  throw new Error('Resume data must be an object.');
 }
 
-fs.writeFileSync(outputPath, JSON.stringify(result, null, 2));
-console.log('Generated', outputPath);
+if (!resumeData.character || typeof resumeData.character !== 'object') {
+  throw new Error('Resume data is missing a character profile.');
+}
+
+if (!Array.isArray(resumeData.milestones)) {
+  throw new Error('Resume data is missing milestones.');
+}
+
+fs.writeFileSync(outputPath, JSON.stringify(resumeData, null, 2) + '\n');
+console.log('Copied resume data to', outputPath);


### PR DESCRIPTION
## Summary
- update the play mode viewer to render character and milestone data from the new resume schema
- restyle play mode slides for milestone details to remain readable with expanded content
- point the conversion script at app/src/resume.json so cv.json stays in sync with the game data

## Testing
- node scripts/convert-cv.js


------
https://chatgpt.com/codex/tasks/task_e_690b9c78654483279023db963c1005c6